### PR TITLE
Create script in runner to convert opset versions

### DIFF
--- a/systolic_runner/converter/convert_to_opset9.py
+++ b/systolic_runner/converter/convert_to_opset9.py
@@ -1,0 +1,16 @@
+import onnx, sys
+from onnx import version_converter, helper
+
+# Preprocessing: load the model to be converted.
+model_path = sys.argv[1]
+
+original_model = onnx.load(model_path)
+
+#print('The model before conversion:\n{}'.format(original_model))
+
+converted_model = version_converter.convert_version(original_model, 9)
+
+#print('The model after conversion:\n{}'.format(converted_model))
+
+new_model_path = model_path[:-5] + "_op9.onnx"
+onnx.save(converted_model, new_model_path)


### PR DESCRIPTION
Create a script `convert_to_opset9.py` that takes in an ONNX model of opset version 7 as the first argument on the command line and converts it to one of version 9. The new file has the same name as the old one with a "_op9" before the file extension.